### PR TITLE
Clorm conda recipe gets the version number from setup.py

### DIFF
--- a/clorm/meta.yaml
+++ b/clorm/meta.yaml
@@ -1,9 +1,9 @@
 {% set name = 'clorm' %}
-{% set version = '1.0.2' %}
+{% set data = load_setup_py_data() %}
 
 package:
   name: {{ name }}
-  version: {{ version }}
+  version: {{ data.get('version') }}
 
 source:
   git_url: https://github.com/potassco/{{ name }}.git


### PR DESCRIPTION
Modified the clorm recipe to use the conda function load_setup_py_data()  to load the clorm setup.py so that it can get the version number from the setup meta data. Going forward there shouldn't be a need to update the recipe when releasing a new clorm version.